### PR TITLE
190423 update requirement

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ CanDIG-ingest
 ==============
 
 Routines for ingesting metadata into a CanDIG 1.0 server
-Requires [ga4gh-server](https://github.com/ga4gh/ga4gh-server), 
+Requires [candig-server](https://github.com/candig/candig-server),
 [docopt](http://docopt.readthedocs.io/en/latest/)
 and [pandas](https://github.com/pandas-dev/pandas).
 
@@ -20,10 +20,10 @@ You can run the ingestion and test a server with the resulting repo as follows
     cd test_server
     source bin/activate
     pip install --upgrade pip setuptools
-    pip install git+https://github.com/CanDIG/candig-schemas.git@develop#egg=ga4gh_schemas
-    pip install git+https://github.com/CanDIG/candig-client.git@authz#egg=ga4gh_client
-    pip install git+https://github.com/CanDIG/candig-server.git@develop#egg=ga4gh_server
-    pip install git+https://github.com/CanDIG/candig-ingest.git
+    pip install git+https://github.com/CanDIG/candig-schemas.git@v0.7.0
+    pip install git+https://github.com/CanDIG/candig-client.git@v0.7.0
+    pip install git+https://github.com/CanDIG/candig-server.git@v0.9.2
+    pip install git+https://github.com/CanDIG/candig-ingest.git@v1.2.0
     
     # setup initial peers
     mkdir -p ga4gh/server/templates
@@ -35,28 +35,28 @@ You can run the ingestion and test a server with the resulting repo as follows
 
     # optional
     # add peer site addresses
-    ga4gh_repo add-peer ga4gh-example-data/registry.db <peer site IP address, like: http://127.0.0.1:8001>
+    candig_repo add-peer ga4gh-example-data/registry.db <peer site IP address, like: http://127.0.0.1:8001>
 
     # optional
     # create dataset for reads and variants
-    ga4gh_repo add-dataset --description "Reads and variants dataset" ga4gh-example-data/registry.db read_and_variats_dataset
+    candig_repo add-dataset --description "Reads and variants dataset" ga4gh-example-data/registry.db read_and_variats_dataset
 
     # optinal
     # add reference set, data source: https://www.ncbi.nlm.nih.gov/grc/human/ or http://genome.wustl.edu/pub/reference/
-    ga4gh_repo add-referenceset ga4gh-example-data/registry.db <path to downloaded reference set, like GRCh37-lite.fa> -d "GRCh37-lite human reference genome" --name GRCh37-lite --sourceUri "http://genome.wustl.edu/pub/reference/GRCh37-lite/GRCh37-lite.fa.gz"
+    candig_repo add-referenceset ga4gh-example-data/registry.db <path to downloaded reference set, like GRCh37-lite.fa> -d "GRCh37-lite human reference genome" --name GRCh37-lite --sourceUri "http://genome.wustl.edu/pub/reference/GRCh37-lite/GRCh37-lite.fa.gz"
 
     # optional
     # add reads
-    ga4gh_repo add-readgroupset -r -I <path to bam index file> -R GRCh37-lite ga4gh-example-data/registry.db read_and_variats_dataset <path to bam file>
+    candig_repo add-readgroupset -r -I <path to bam index file> -R GRCh37-lite ga4gh-example-data/registry.db read_and_variats_dataset <path to bam file>
 
     # optional
     # add variants
-    ga4gh_repo add-variantset -I <path to variants index file> -R GRCh37-lite ga4gh-example-data/registry.db read_and_variats_dataset <path to vcf file>
+    candig_repo add-variantset -I <path to variants index file> -R GRCh37-lite ga4gh-example-data/registry.db read_and_variats_dataset <path to vcf file>
     
     # optional
     # add sequence ontology set
     # wget https://raw.githubusercontent.com/The-Sequence-Ontology/SO-Ontologies/master/so.obo
-    ga4gh_repo add-ontology ga4gh-example-data/registry.db <path to sequence ontology set, like: so.obo> -n so-xp
+    candig_repo add-ontology ga4gh-example-data/registry.db <path to sequence ontology set, like: so.obo> -n so-xp
 
     # optional
     # add features/annotations
@@ -75,21 +75,21 @@ You can run the ingestion and test a server with the resulting repo as follows
     # python generate_gff3_db.py -i gencode.v27.annotation.gff3 -o gencode.v27.annotation.db -v    
     #
     # add featureset
-    ga4gh_repo add-featureset ga4gh-example-data/registry.db read_and_variats_dataset <path to the annotation.db> -R GRCh37-lite -O so-xp
+    candig_repo add-featureset ga4gh-example-data/registry.db read_and_variats_dataset <path to the annotation.db> -R GRCh37-lite -O so-xp
 
     # optional
     # add phenotype association set from Monarch Initiative
     # wget http://nif-crawler.neuinfo.org/monarch/ttl/cgd.ttl
-    ga4gh_repo add-phenotypeassociationset ga4gh-example-data/registry.db read_and_variats_dataset <path to the folder containing cdg.ttl>
+    candig_repo add-phenotypeassociationset ga4gh-example-data/registry.db read_and_variats_dataset <path to the folder containing cdg.ttl>
 
     # optional
     # add disease ontology set, like: NCIT
     # wget http://purl.obolibrary.org/obo/ncit.obo
-    ga4gh_repo add-ontology -n NCIT ga4gh-example-data/registry.db ncit.obo
+    candig_repo add-ontology -n NCIT ga4gh-example-data/registry.db ncit.obo
 
     # launch the server
     # at different IP and/or port: ga4gh_server --host 127.0.0.1 --port 8000
-    ga4gh_server --host 127.0.0.1 --port 8000 -c NoAuth
+    candig_server --host 127.0.0.1 --port 8000 -c NoAuth
 
 
     https://127.0.0.1:8000/

--- a/candig/ingest/ingest.py
+++ b/candig/ingest/ingest.py
@@ -20,37 +20,37 @@ import json
 import os
 from docopt import docopt
 
-import ga4gh.server.datarepo as repo
-import ga4gh.server.exceptions as exceptions
+import candig.server.datarepo as repo
+import candig.server.exceptions as exceptions
 
-from ga4gh.server.datamodel.datasets import Dataset
-from ga4gh.server.datamodel.bio_metadata import Individual
-from ga4gh.server.datamodel.bio_metadata import Biosample
-from ga4gh.server.datamodel.clinical_metadata import Patient
-from ga4gh.server.datamodel.clinical_metadata import Enrollment
-from ga4gh.server.datamodel.clinical_metadata import Consent
-from ga4gh.server.datamodel.clinical_metadata import Diagnosis
-from ga4gh.server.datamodel.clinical_metadata import Sample
-from ga4gh.server.datamodel.clinical_metadata import Treatment
-from ga4gh.server.datamodel.clinical_metadata import Outcome
-from ga4gh.server.datamodel.clinical_metadata import Complication
-from ga4gh.server.datamodel.clinical_metadata import Tumourboard
-from ga4gh.server.datamodel.clinical_metadata import Chemotherapy
-from ga4gh.server.datamodel.clinical_metadata import Radiotherapy
-from ga4gh.server.datamodel.clinical_metadata import Immunotherapy
-from ga4gh.server.datamodel.clinical_metadata import Surgery
-from ga4gh.server.datamodel.clinical_metadata import Celltransplant
-from ga4gh.server.datamodel.clinical_metadata import Slide
-from ga4gh.server.datamodel.clinical_metadata import Study
-from ga4gh.server.datamodel.clinical_metadata import Labtest
-from ga4gh.server.datamodel.bio_metadata import Experiment
-from ga4gh.server.datamodel.bio_metadata import Analysis
-from ga4gh.server.datamodel.pipeline_metadata import Extraction
-from ga4gh.server.datamodel.pipeline_metadata import Sequencing
-from ga4gh.server.datamodel.pipeline_metadata import Alignment
-from ga4gh.server.datamodel.pipeline_metadata import VariantCalling
-from ga4gh.server.datamodel.pipeline_metadata import FusionDetection
-from ga4gh.server.datamodel.pipeline_metadata import ExpressionAnalysis
+from candig.server.datamodel.datasets import Dataset
+from candig.server.datamodel.bio_metadata import Individual
+from candig.server.datamodel.bio_metadata import Biosample
+from candig.server.datamodel.clinical_metadata import Patient
+from candig.server.datamodel.clinical_metadata import Enrollment
+from candig.server.datamodel.clinical_metadata import Consent
+from candig.server.datamodel.clinical_metadata import Diagnosis
+from candig.server.datamodel.clinical_metadata import Sample
+from candig.server.datamodel.clinical_metadata import Treatment
+from candig.server.datamodel.clinical_metadata import Outcome
+from candig.server.datamodel.clinical_metadata import Complication
+from candig.server.datamodel.clinical_metadata import Tumourboard
+from candig.server.datamodel.clinical_metadata import Chemotherapy
+from candig.server.datamodel.clinical_metadata import Radiotherapy
+from candig.server.datamodel.clinical_metadata import Immunotherapy
+from candig.server.datamodel.clinical_metadata import Surgery
+from candig.server.datamodel.clinical_metadata import Celltransplant
+from candig.server.datamodel.clinical_metadata import Slide
+from candig.server.datamodel.clinical_metadata import Study
+from candig.server.datamodel.clinical_metadata import Labtest
+from candig.server.datamodel.bio_metadata import Experiment
+from candig.server.datamodel.bio_metadata import Analysis
+from candig.server.datamodel.pipeline_metadata import Extraction
+from candig.server.datamodel.pipeline_metadata import Sequencing
+from candig.server.datamodel.pipeline_metadata import Alignment
+from candig.server.datamodel.pipeline_metadata import VariantCalling
+from candig.server.datamodel.pipeline_metadata import FusionDetection
+from candig.server.datamodel.pipeline_metadata import ExpressionAnalysis
 
 
 class CandigRepo(object):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ga4gh-server
+candig-server
 pandas
 docopt

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     "docopt",
-    "ga4gh-server",
+    "candig-server",
     "pandas",
     ]
 
@@ -25,7 +25,7 @@ test_requirements = [
 
 setup(
     name='candig-ingest',
-    version='1.0.0',
+    version='1.1.0',
     description='Routines for ingesting metadata to a CanDIG repository',
     long_description='\n\n'.join((readme, history)),
     url='https://github.com/CanDIG/candig-ingest.git',

--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,12 @@ test_requirements = [
 
 setup(
     name='candig-ingest',
-    version='1.1.0',
+    version='1.2.0',
     description='Routines for ingesting metadata to a CanDIG repository',
     long_description='\n\n'.join((readme, history)),
     url='https://github.com/CanDIG/candig-ingest.git',
     author='CanDIG team',
-    author_email='',
+    author_email='info@distributedgenomics.ca',
     packages=find_packages(include=['candig', 'candig.ingest']),
     namespace_packages=['candig'],
     entry_points={


### PR DESCRIPTION
Several updates here:

- Due to the change of namespace in the candig-server, references to ga4gh.* have been changed to candig.*
- Previously, the installation instructions in Readme has a few outdated commands, urls, etc. These have been replaced with the most up-to-date ones.
- Author email has been added.
- Version has been bumped up to 1.2.0.

The previous PR https://github.com/CanDIG/candig-ingest/pull/2 was closed because I wasn't able to add @zbozoky as a reviewer 