### PR TITLE
Update `ingest --version` command (#10)

### DIFF
--- a/candig/ingest/ingest.py
+++ b/candig/ingest/ingest.py
@@ -20,6 +20,8 @@ import json
 import os
 from docopt import docopt
 
+import candig.ingest._version as version
+
 import candig.server.datarepo as repo
 import candig.server.exceptions as exceptions
 
@@ -348,7 +350,7 @@ def main():
     """
     """
     # Parse arguments
-    args = docopt(__doc__, version='ingest from-git-master')
+    args = docopt(__doc__, version='ingest ' + str(version.version))
     repo_filename = args['<repo_filename>']
     dataset_name = args['<dataset_name>']
     metadata_json = args['<metadata_json>']

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ test_requirements = [
 
 setup(
     name='candig-ingest',
-    version='1.3.0',
+    version='1.3.1',
+    use_scm_version={"write_to": "candig/ingest/_version.py"},
+    setup_requires=['setuptools_scm'],
     description='Routines for ingesting metadata to a CanDIG repository',
     long_description=readme,
     url='https://github.com/CanDIG/candig-ingest.git',
@@ -41,4 +43,9 @@ setup(
     zip_safe=False,
     license="GNU General Public License v3",
     keywords='candig-ingest',
+    classifiers=[
+        'Natural Language :: English',
+        'Programming Language :: Python :: 3.6',
+        'Topic :: Scientific/Engineering :: Bio-Informatics',
+    ]
    )


### PR DESCRIPTION
* 2to3 (#5)

* first run of 2to3

* modify json.load

* remove unnecessary parantheses

* remove HISTORY.rst

* bump version to 1.3.0

* remove usage of history.rst

* update README

* update setup.py and how to read pkgs version

* write new _version at install

* requires setuptools_scm

* update version import

* update ingest versioning