### PR TITLE
support batch update

### DIFF
--- a/candig/ingest/ingest.py
+++ b/candig/ingest/ingest.py
@@ -1,20 +1,19 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-ingest.py - Creates a new dataset and parses metadata information into it.
-It populates all metadata tables
+ingest.py - Creates a new dataset for candig-server and batch ingest or update data for all clinical and pipeline tables.
 
 Usage:
   ingest [-h Help] [-v Version] [-d Description] [--overwrite] <repo_filename> <dataset_name> <metadata_json>
 
 Options:
-  -h --help        Show this screen
-  -v --version     Version
-  -d <description> A text description of the dataset.
+  -h --help        Show this screen.
+  -v --version     Version.
+  -d <description> A text description of the dataset to be created.
   --overwrite      If this flag is specified, existing records will be overwritten.
-  <repo_filename>  Repository filename and path information
-  <dataset_name>   Dataset name = project name
-  <metadata_json>  Metadata json object filename and path information
+  <repo_filename>  Path to the candig-server's SQLite database file.
+  <dataset_name>   Dataset name.
+  <metadata_json>  Path to the json file that contains clinical and pipeline data.
 
 """
 

--- a/candig/ingest/ingest.py
+++ b/candig/ingest/ingest.py
@@ -5,12 +5,13 @@ ingest.py - Creates a new dataset and parses metadata information into it.
 It populates all metadata tables
 
 Usage:
-  ingest [-h Help] [-v Version] [-d Description] <repo_filename> <dataset_name> <metadata_json>
+  ingest [-h Help] [-v Version] [-d Description] [--overwrite] <repo_filename> <dataset_name> <metadata_json>
 
 Options:
   -h --help        Show this screen
   -v --version     Version
-  -d <description>  A text description of the dataset.
+  -d <description> A text description of the dataset.
+  --overwrite      If this flag is specified, existing records will be overwritten.
   <repo_filename>  Repository filename and path information
   <dataset_name>   Dataset name = project name
   <metadata_json>  Metadata json object filename and path information
@@ -76,119 +77,142 @@ class CandigRepo(object):
             'Patient': {
                 'table': Patient,
                 'local_id': ['patientId'],
-                'repo_add': self.add_patient
+                'repo_add': self.add_patient,
+                'repo_update': self.update_patient
             },
             'Enrollment': {
                 'table': Enrollment,
                 'local_id': ["patientId", "enrollmentApprovalDate"],
-                'repo_add': self.add_enrollment
+                'repo_add': self.add_enrollment,
+                'repo_update': self.update_enrollment
             },
             'Consent': {
                 'table': Consent,
                 'local_id': ["patientId", "consentDate"],
-                'repo_add': self.add_consent
+                'repo_add': self.add_consent,
+                'repo_update': self.update_consent
             },
             'Diagnosis': {
                 'table': Diagnosis,
                 'local_id': ["patientId", "diagnosisDate"],
-                'repo_add': self.add_diagnosis
+                'repo_add': self.add_diagnosis,
+                'repo_update': self.update_diagnosis
             },
             'Sample': {
                 'table': Sample,
                 'local_id': ["patientId", "sampleId"],
-                'repo_add': self.add_sample
+                'repo_add': self.add_sample,
+                'repo_update': self.update_sample
             },
             'Treatment': {
                 'table': Treatment,
                 'local_id': ["patientId", "startDate"],
-                'repo_add': self.add_treatment
+                'repo_add': self.add_treatment,
+                'repo_update': self.update_treatment
             },
             'Outcome': {
                 'table': Outcome,
                 'local_id': ["patientId", "dateOfAssessment"],
-                'repo_add': self.add_outcome
+                'repo_add': self.add_outcome,
+                'repo_update': self.update_outcome
             },
             'Complication': {
                 'table': Complication,
                 'local_id': ["patientId", "date"],
-                'repo_add': self.add_complication
+                'repo_add': self.add_complication,
+                'repo_update': self.update_complication
             },
             'Tumourboard': {
                 'table': Tumourboard,
                 'local_id': ["patientId", "dateOfMolecularTumorBoard"],
-                'repo_add': self.add_tumourboard
+                'repo_add': self.add_tumourboard,
+                'repo_update': self.update_tumourboard
             },
             'Chemotherapy': {
                 'table': Chemotherapy,
                 'local_id': ["patientId", "treatmentPlanId", "systematicTherapyAgentName"],
-                'repo_add': self.add_chemotherapy
+                'repo_add': self.add_chemotherapy,
+                'repo_update': self.update_chemotherapy
             },
             'Radiotherapy': {
                 'table': Radiotherapy,
                 'local_id': ["patientId", "courseNumber", "treatmentPlanId", "startDate"],
-                'repo_add': self.add_radiotherapy
+                'repo_add': self.add_radiotherapy,
+                'repo_update': self.update_radiotherapy
             },
             'Immunotherapy': {
                 'table': Immunotherapy,
                 'local_id': ["patientId", "treatmentPlanId", "startDate"],
-                'repo_add': self.add_immunotherapy
+                'repo_add': self.add_immunotherapy,
+                'repo_update': self.update_immunotherapy
             },
             'Surgery': {
                 'table': Surgery,
                 'local_id': ["patientId", "treatmentPlanId", "startDate", "sampleId"],
-                'repo_add': self.add_surgery
+                'repo_add': self.add_surgery,
+                'repo_update': self.update_surgery
             },
             'Celltransplant': {
                 'table': Celltransplant,
                 'local_id': ["patientId", "treatmentPlanId", "startDate"],
-                'repo_add': self.add_celltransplant
+                'repo_add': self.add_celltransplant,
+                'repo_update': self.update_celltransplant
             },
             'Slide': {
                 'table': Slide,
                 'local_id': ["patientId", "slideId"],
-                'repo_add': self.add_slide
+                'repo_add': self.add_slide,
+                'repo_update': self.update_slide
             },
             'Study': {
                 'table': Study,
                 'local_id': ["patientId", "startDate"],
-                'repo_add': self.add_study
+                'repo_add': self.add_study,
+                'repo_update': self.update_study
             },
             'Labtest': {
                 'table': Labtest,
                 'local_id': ["patientId", "startDate"],
-                'repo_add': self.add_labtest
+                'repo_add': self.add_labtest,
+                'repo_update': self.update_labtest
             }
         }
         self.pipeline_metadata_map = {
             'Extraction': {
                 'table': Extraction,
                 'local_id': ["sampleId", "extractionId"],
-                'repo_add': self.add_extraction
+                'repo_add': self.add_extraction,
+                'repo_update': self.update_extraction
             },
             'Sequencing': {
                 'table': Sequencing,
                 'local_id': ["sampleId", "sequencingId"],
-                'repo_add': self.add_sequencing
+                'repo_add': self.add_sequencing,
+                'repo_update': self.update_sequencing
             },
             'Alignment': {
                 'table': Alignment,
                 'local_id': ["sampleId", "alignmentId"],
-                'repo_add': self.add_alignment
+                'repo_add': self.add_alignment,
+                'repo_update': self.update_alignment
             },
             'VariantCalling': {
                 'table': VariantCalling,
                 'local_id': ["sampleId", "variantCallingId"],
-                'repo_add': self.add_variant_calling
+                'repo_add': self.add_variant_calling,
+                'repo_update': self.update_variant_calling
             },
             'FusionDetection': {
                 'table': FusionDetection,
                 'local_id': ["sampleId", "fusionDetectionId"],
-                'repo_add': self.add_fusion_detection
+                'repo_add': self.add_fusion_detection,
+                'repo_update': self.update_fusion_detection
             },
             'ExpressionAnalysis': {
                 'table': ExpressionAnalysis,
                 'local_id': ["sampleId", "expressionAnalysisId"],
-                'repo_add': self.add_expression_analysis
+                'repo_add': self.add_expression_analysis,
+                'repo_update': self.update_expression_analysis
             }
         }
 
@@ -206,146 +230,256 @@ class CandigRepo(object):
         self._repo.verify()
         self._repo.close()
 
-    def add_dataset(self, dataset):
-        self._repo.insertDataset(dataset)
+    def _commit_record(self):
         self._repo.commit()
         self._repo.verify()
+
+    def add_dataset(self, dataset):
+        self._repo.insertDataset(dataset)
+        self._commit_record()
 
     def add_patient(self, patient):
         self._repo.insertPatient(patient)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_enrollment(self, enrollment):
         self._repo.insertEnrollment(enrollment)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_consent(self, consent):
         self._repo.insertConsent(consent)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_diagnosis(self, diagnosis):
         self._repo.insertDiagnosis(diagnosis)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_sample(self, sample):
         self._repo.insertSample(sample)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_treatment(self, treatment):
         self._repo.insertTreatment(treatment)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_outcome(self, outcome):
         self._repo.insertOutcome(outcome)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_complication(self, complication):
         self._repo.insertComplication(complication)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_tumourboard(self, tumourboard):
         self._repo.insertTumourboard(tumourboard)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_chemotherapy(self, chemotherapy):
         self._repo.insertChemotherapy(chemotherapy)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_radiotherapy(self, radiotherapy):
         self._repo.insertRadiotherapy(radiotherapy)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_immunotherapy(self, immunotherapy):
         self._repo.insertImmunotherapy(immunotherapy)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_surgery(self, surgery):
         self._repo.insertSurgery(surgery)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_celltransplant(self, celltransplant):
         self._repo.insertCelltransplant(celltransplant)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_slide(self, slide):
         self._repo.insertSlide(slide)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_study(self, study):
         self._repo.insertStudy(study)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_labtest(self, labtest):
         self._repo.insertLabtest(labtest)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_individual(self, person):
         self._repo.insertIndividual(person)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_biosample(self, biosample):
         self._repo.insertBiosample(biosample)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_experiment(self, experiment):
         self._repo.insertExperiment(experiment)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_analysis(self, analysis):
         self._repo.insertAnalysis(analysis)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_extraction(self, extraction):
         self._repo.insertExtraction(extraction)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_sequencing(self, sequencing):
         self._repo.insertSequencing(sequencing)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_alignment(self, alignment):
         self._repo.insertAlignment(alignment)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_variant_calling(self, variant_calling):
         self._repo.insertVariantCalling(variant_calling)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_fusion_detection(self, fusion_detection):
         self._repo.insertFusionDetection(fusion_detection)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
     def add_expression_analysis(self, expression_analysis):
         self._repo.insertExpressionAnalysis(expression_analysis)
-        self._repo.commit()
-        self._repo.verify()
+        self._commit_record()
 
+    def update_patient(self, patient):
+        self._repo.removePatient(patient)
+        self._repo.insertPatient(patient)
+        self._commit_record()
+
+    def update_enrollment(self, enrollment):
+        self._repo.removeEnrollment(enrollment)
+        self._repo.insertEnrollment(enrollment)
+        self._commit_record()
+
+    def update_consent(self, consent):
+        self._repo.removeConsent(consent)
+        self._repo.insertConsent(consent)
+        self._commit_record()
+
+    def update_diagnosis(self, diagnosis):
+        self._repo.removeDiagnosis(diagnosis)
+        self._repo.insertDiagnosis(diagnosis)
+        self._commit_record()
+
+    def update_sample(self, sample):
+        self._repo.removeSample(sample)
+        self._repo.insertSample(sample)
+        self._commit_record()
+
+    def update_treatment(self, treatment):
+        self._repo.removeTreatment(treatment)
+        self._repo.insertTreatment(treatment)
+        self._commit_record()
+
+    def update_outcome(self, outcome):
+        self._repo.removeOutcome(outcome)
+        self._repo.insertOutcome(outcome)
+        self._commit_record()
+
+    def update_complication(self, complication):
+        self._repo.removeComplication(complication)
+        self._repo.insertComplication(complication)
+        self._commit_record()
+
+    def update_tumourboard(self, tumourboard):
+        self._repo.removeTumourboard(tumourboard)
+        self._repo.insertTumourboard(tumourboard)
+        self._commit_record()
+
+    def update_chemotherapy(self, chemotherapy):
+        self._repo.removeChemotherapy(chemotherapy)
+        self._repo.insertChemotherapy(chemotherapy)
+        self._commit_record()
+
+    def update_radiotherapy(self, radiotherapy):
+        self._repo.removeRadiotherapy(radiotherapy)
+        self._repo.insertRadiotherapy(radiotherapy)
+        self._commit_record()
+
+    def update_immunotherapy(self, immunotherapy):
+        self._repo.removeImmunotherapy(immunotherapy)
+        self._repo.insertImmunotherapy(immunotherapy)
+        self._commit_record()
+
+    def update_surgery(self, surgery):
+        self._repo.removeSurgery(surgery)
+        self._repo.insertSurgery(surgery)
+        self._commit_record()
+
+    def update_celltransplant(self, celltransplant):
+        self._repo.removeCelltransplant(celltransplant)
+        self._repo.insertCelltransplant(celltransplant)
+        self._commit_record()
+
+    def update_slide(self, slide):
+        self._repo.removeSlide(slide)
+        self._repo.insertSlide(slide)
+        self._commit_record()
+
+    def update_study(self, study):
+        self._repo.removeStudy(study)
+        self._repo.insertStudy(study)
+        self._commit_record()
+
+    def update_labtest(self, labtest):
+        self._repo.removeLabtest(labtest)
+        self._repo.insertLabtest(labtest)
+        self._commit_record()
+
+    def update_individual(self, person):
+        self._repo.removeIndividual(person)
+        self._repo.insertIndividual(person)
+        self._commit_record()
+
+    def update_biosample(self, biosample):
+        self._repo.removeBiosample(biosample)
+        self._repo.insertBiosample(biosample)
+        self._commit_record()
+
+    def update_experiment(self, experiment):
+        self._repo.removeExperiment(experiment)
+        self._repo.insertExperiment(experiment)
+        self._commit_record()
+
+    def update_analysis(self, analysis):
+        self._repo.removeAnalysis(analysis)
+        self._repo.insertAnalysis(analysis)
+        self._commit_record()
+
+    def update_extraction(self, extraction):
+        self._repo.removeExtraction(extraction)
+        self._repo.insertExtraction(extraction)
+        self._commit_record()
+
+    def update_sequencing(self, sequencing):
+        self._repo.removeSequencing(sequencing)
+        self._repo.insertSequencing(sequencing)
+        self._commit_record()
+
+    def update_alignment(self, alignment):
+        self._repo.removeAlignment(alignment)
+        self._repo.insertAlignment(alignment)
+        self._commit_record()
+
+    def update_variant_calling(self, variant_calling):
+        self._repo.removeVariantCalling(variant_calling)
+        self._repo.insertVariantCalling(variant_calling)
+        self._commit_record()
+
+    def update_fusion_detection(self, fusion_detection):
+        self._repo.removeFusionDetection(fusion_detection)
+        self._repo.insertFusionDetection(fusion_detection)
+        self._commit_record()
+
+    def update_expression_analysis(self, expression_analysis):
+        self._repo.removeExpressionAnalysis(expression_analysis)
+        self._repo.insertExpressionAnalysis(expression_analysis)
+        self._commit_record()
 
 def main():
     """
@@ -379,6 +513,7 @@ def main():
                 'metadata': repo.clinical_metadata_map,
                 'pipeline_metadata': repo.pipeline_metadata_map
             }
+
             metadata_key = list(metadata.keys())[0]
 
             # Iterate through metadata file type based on key and update the dataset
@@ -412,8 +547,13 @@ def main():
                         try:
                             metadata_map[metadata_key][table]['repo_add'](repo_obj)
                         except exceptions.DuplicateNameException:
-                            print("Skipped: Duplicate {0} detected for local name: {1} {2}".format(
-                                table, local_id, metadata_map[metadata_key][table]['local_id']))
+                            if args['--overwrite']:
+                                metadata_map[metadata_key][table]['repo_update'](repo_obj)
+                                print("Overwriting record for local identifier {} at {} table".format(
+                                    local_id, table))
+                            else:
+                                print("Skipped: Duplicate {0} detected for local name: {1} {2}".format(
+                                    table, local_id, metadata_map[metadata_key][table]['local_id']))
 
     return None
 

--- a/candig/ingest/ingest.py
+++ b/candig/ingest/ingest.py
@@ -306,22 +306,6 @@ class CandigRepo(object):
         self._repo.insertLabtest(labtest)
         self._commit_record()
 
-    def add_individual(self, person):
-        self._repo.insertIndividual(person)
-        self._commit_record()
-
-    def add_biosample(self, biosample):
-        self._repo.insertBiosample(biosample)
-        self._commit_record()
-
-    def add_experiment(self, experiment):
-        self._repo.insertExperiment(experiment)
-        self._commit_record()
-
-    def add_analysis(self, analysis):
-        self._repo.insertAnalysis(analysis)
-        self._commit_record()
-
     def add_extraction(self, extraction):
         self._repo.insertExtraction(extraction)
         self._commit_record()
@@ -429,26 +413,6 @@ class CandigRepo(object):
     def update_labtest(self, labtest):
         self._repo.removeLabtest(labtest)
         self._repo.insertLabtest(labtest)
-        self._commit_record()
-
-    def update_individual(self, person):
-        self._repo.removeIndividual(person)
-        self._repo.insertIndividual(person)
-        self._commit_record()
-
-    def update_biosample(self, biosample):
-        self._repo.removeBiosample(biosample)
-        self._repo.insertBiosample(biosample)
-        self._commit_record()
-
-    def update_experiment(self, experiment):
-        self._repo.removeExperiment(experiment)
-        self._repo.insertExperiment(experiment)
-        self._commit_record()
-
-    def update_analysis(self, analysis):
-        self._repo.removeAnalysis(analysis)
-        self._repo.insertAnalysis(analysis)
         self._commit_record()
 
     def update_extraction(self, extraction):


### PR DESCRIPTION
New:

- Support `--overwrite` flag, when specified, overwrite all existing records with identical identifiers. This allows us to run a nightly sync against redcap data.

- A new internal helper that calls `self._repo.commit()` and  `self._repo.verify()`, I am however not even sure if this is needed at all, I feel like it's not needed. The code of `self._repo.commit()` and  `self._repo.verify()` seem to indicate that they don't really do anything.

- Remove these because they are not used at all

```
-    def add_individual(self, person):
-        self._repo.insertIndividual(person)
-        self._commit_record()
-
-    def add_biosample(self, biosample):
-        self._repo.insertBiosample(biosample)
-        self._commit_record()
-
-    def add_experiment(self, experiment):
-        self._repo.insertExperiment(experiment)
-        self._commit_record()
-
-    def add_analysis(self, analysis):
-        self._repo.insertAnalysis(analysis)
-        self._commit_record()
```