### PR TITLE
Support local id at ingest

### DIFF
--- a/candig/ingest/ingest.py
+++ b/candig/ingest/ingest.py
@@ -490,22 +490,31 @@ def main():
                             records = [records]
 
                         for record in records:
-                            local_id_list = []
-                            for x in metadata_map[metadata_key][table]['local_id']:
-                                if record.get(x):
-                                    local_id_list.append(record[x])
-                                else:
-                                    print("Skipped: Missing 1 or more primary identifiers for record in: {0} needs {1}, received {2}".format(
-                                        table,
-                                        metadata_map[metadata_key][table]['local_id'],
-                                        local_id_list,
-                                        ))
-                                    local_id_list = None
-                                    break
-                            if not local_id_list:
-                                continue
+                            localId = ''
 
-                            local_id = "_".join(local_id_list)
+                            # If localId is present, use it as the localId
+                            # Otherwise, attempt to contruct localId from predetermined fields
+                            if record.get('localId'):
+                                local_id = record.get('localId')
+
+                            else:
+                                local_id_list = []
+                                for x in metadata_map[metadata_key][table]['local_id']:
+                                    if record.get(x):
+                                        local_id_list.append(record[x])
+                                    else:
+                                        print("Skipped: Missing 1 or more primary identifiers for record in: {0} needs {1}, received {2}".format(
+                                            table,
+                                            metadata_map[metadata_key][table]['local_id'],
+                                            local_id_list,
+                                            ))
+                                        print("You may also specify localId to uniquely denote records.")
+                                        local_id_list = None
+                                        break
+                                if not local_id_list:
+                                    continue
+
+                                local_id = "_".join(local_id_list)
 
                             obj = metadata_map[metadata_key][table]['table'](dataset, localId=local_id)
                             repo_obj = obj.populateFromJson(json.dumps(record))

--- a/candig/ingest/ingest.py
+++ b/candig/ingest/ingest.py
@@ -490,7 +490,6 @@ def main():
                             records = [records]
 
                         for record in records:
-                            localId = ''
 
                             # If localId is present, use it as the localId
                             # Otherwise, attempt to contruct localId from predetermined fields

--- a/candig/ingest/load_tiers.py
+++ b/candig/ingest/load_tiers.py
@@ -86,7 +86,7 @@ def get_updated_record(record, table_name, project, tiers):
 
             updated_record[field] = record[field]
 
-            if (table_name, field) in tiers.index:
+            if (table_name, field) in tiers.index and field != "localId":
                 tier = tiers.loc[[(table_name, field)], project.lower()]
                 updated_record['{0}Tier'.format(field)] = int(tier)
 

--- a/candig/ingest/load_tiers.py
+++ b/candig/ingest/load_tiers.py
@@ -86,13 +86,14 @@ def get_updated_record(record, table_name, project, tiers):
 
             updated_record[field] = record[field]
 
-            if (table_name, field) in tiers.index and field != "localId":
+            if (table_name, field) in tiers.index:
                 tier = tiers.loc[[(table_name, field)], project.lower()]
                 updated_record['{0}Tier'.format(field)] = int(tier)
 
             else:
-                logger.error('Unassigned tier info for {table}.{field}'.format(
-                    table=table_name, field=field))
+                if field != 'localId':
+                    logger.error('Unassigned tier info for {table}.{field}'.format(
+                        table=table_name, field=field))
 
     return updated_record
 


### PR DESCRIPTION
This PR introduces a new way of ingesting records with incomplete information.

Previously, each record relies on certainly fields to generate a `localId`, for example, for `Outcome` table, it would be `PatientId` and `DataOfAssessment`, this is not always possible. To work around this issue, users are now given the option to specify their own `localId`.

It should not break any previous functionalities.

Documentation will need to be updated separately on the candig-server side, pending.