### PR TITLE
update localId

### DIFF
--- a/candig/ingest/ingest.py
+++ b/candig/ingest/ingest.py
@@ -493,9 +493,12 @@ def main():
 
                             # If localId is present, use it as the localId
                             # Otherwise, attempt to contruct localId from predetermined fields
-                            if record.get('localId'):
-                                local_id = record.get('localId')
 
+                            if record.get('localId') and table in ['Patient', 'Sample']:
+                                print('localId should not be specified for the', table, 'table.')
+                            
+                            if record.get('localId') and table not in ['Patient', 'Sample']:
+                                local_id = record.get('patientId') + record.get('localId')
                             else:
                                 local_id_list = []
                                 for x in metadata_map[metadata_key][table]['local_id']:

--- a/candig/ingest/ingest.py
+++ b/candig/ingest/ingest.py
@@ -510,7 +510,8 @@ def main():
                                             metadata_map[metadata_key][table]['local_id'],
                                             local_id_list,
                                             ))
-                                        print("You may also specify localId to uniquely denote records.")
+                                        if table not in ['Patient', 'Sample']:
+                                            print("You may also specify localId to uniquely denote records.")
                                         local_id_list = None
                                         break
                                 if not local_id_list:

--- a/candig/ingest/ingest.py
+++ b/candig/ingest/ingest.py
@@ -530,8 +530,8 @@ def main():
                                     print("Overwriting record for local identifier {} at {} table".format(
                                         local_id, table))
                                 else:
-                                    print("Skipped: Duplicate {0} detected for local name: {1} {2}".format(
-                                        table, local_id, metadata_map[metadata_key][table]['local_id']))
+                                    print("Skipped: Duplicate {0} record name detected: {1} ".format(
+                                        table, local_id))
 
     return None
 


### PR DESCRIPTION
This PR introduces:

- Automatically including `patientId` when `localId` is supplied.
- `localId` is only used when table is not `Patient` or `Sample`.
- Warning message is changed to `Duplicate {table} record name detected: {localId} `